### PR TITLE
fix: switch to v4 CSS entry point for Tailwind content scanning

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 /* View Transition Animations */
 @keyframes fade-in {


### PR DESCRIPTION
Replace the legacy v3 @tailwind directives with @import "tailwindcss" so that @tailwindcss/postcss v4 runs its full content scan. The old directives caused the scanner to skip theme-dependent utilities (colors, spacing, font sizes, shadows, border radii), leaving only static-value classes in the bundle.

https://claude.ai/code/session_01U5yN7f24NaG5ritwNdTCq8