### PR TITLE
feat: link quiz answers to MDN documentation

### DIFF
--- a/src/components/FeedbackBanner.jsx
+++ b/src/components/FeedbackBanner.jsx
@@ -1,4 +1,16 @@
 import { CheckCircle, XCircle } from 'lucide-react';
+import { getMdnUrl } from '../utils/mdnLinks';
+
+const MdnLink = ({ term, className }) => (
+  <a
+    href={getMdnUrl(term)}
+    target="_blank"
+    rel="noopener noreferrer"
+    className={`underline decoration-2 underline-offset-2 hover:opacity-80 ${className}`}
+  >
+    {term}
+  </a>
+);
 
 export const FeedbackBanner = ({ lastAnswer }) => {
   if (!lastAnswer) return null;
@@ -15,13 +27,16 @@ export const FeedbackBanner = ({ lastAnswer }) => {
       {lastAnswer.correct ? (
         <>
           <CheckCircle size={24} />
-          <span>Correct! {lastAnswer.term}</span>
+          <span>
+            Correct! <MdnLink term={lastAnswer.term} className="text-green-800" />
+          </span>
         </>
       ) : (
         <>
           <XCircle size={24} />
           <span>
-            Wrong! It was {lastAnswer.term}, not {lastAnswer.userAnswer}
+            Wrong! It was <MdnLink term={lastAnswer.term} className="text-red-800" />, not{' '}
+            <MdnLink term={lastAnswer.userAnswer} className="text-red-800" />
           </span>
         </>
       )}

--- a/src/utils/mdnLinks.js
+++ b/src/utils/mdnLinks.js
@@ -1,0 +1,51 @@
+// Maps quiz terms to specific MDN documentation pages
+// Falls back to MDN search if no specific page is available
+
+const mdnBaseUrl = 'https://developer.mozilla.org/en-US';
+
+const mdnPages = {
+  // Glossary terms
+  parameter: '/docs/Glossary/Parameter',
+  argument: '/docs/Glossary/Argument',
+  property: '/docs/Glossary/property/JavaScript',
+  callback: '/docs/Glossary/Callback_function',
+  tuple: '/docs/Glossary/Tuple',
+
+  // JavaScript reference
+  'function body': '/docs/Web/JavaScript/Reference/Statements/function',
+  'square brackets': '/docs/Web/JavaScript/Reference/Global_Objects/Array',
+  'curly braces': '/docs/Web/JavaScript/Reference/Statements/block',
+  parentheses: '/docs/Web/JavaScript/Guide/Functions',
+  index: '/docs/Web/JavaScript/Reference/Global_Objects/Array#accessing_array_elements',
+  destructuring: '/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment',
+  'spread operator': '/docs/Web/JavaScript/Reference/Operators/Spread_syntax',
+  'ternary operator': '/docs/Web/JavaScript/Reference/Operators/Conditional_operator',
+  'optional chaining': '/docs/Web/JavaScript/Reference/Operators/Optional_chaining',
+  'nullish coalescing': '/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing',
+  'arrow function': '/docs/Web/JavaScript/Reference/Functions/Arrow_functions',
+  await: '/docs/Web/JavaScript/Reference/Operators/await',
+  inheritance: '/docs/Learn/JavaScript/Objects/Classes_in_JavaScript#inheritance',
+  'object literal': '/docs/Web/JavaScript/Reference/Operators/Object_initializer',
+  'default export': '/docs/Web/JavaScript/Reference/Statements/export#using_the_default_export',
+  'named export': '/docs/Web/JavaScript/Reference/Statements/export',
+  void: '/docs/Web/JavaScript/Reference/Operators/void',
+
+  // TypeScript-specific terms - fall back to search
+  // These will use the default search fallback
+};
+
+/**
+ * Get an MDN URL for a quiz term
+ * @param {string} term - The quiz answer term
+ * @returns {string} The MDN URL (direct page or search)
+ */
+export function getMdnUrl(term) {
+  const normalizedTerm = term.toLowerCase();
+
+  if (mdnPages[normalizedTerm]) {
+    return `${mdnBaseUrl}${mdnPages[normalizedTerm]}`;
+  }
+
+  // Fall back to MDN search for terms without specific pages
+  return `${mdnBaseUrl}/search?q=${encodeURIComponent(term)}`;
+}


### PR DESCRIPTION
Answers in success/failure messages now link to relevant MDN pages.
Uses direct URLs for common JavaScript terms and falls back to MDN
search for TypeScript-specific terminology.

https://claude.ai/code/session_01Y29tXHWfKjY5bey1meuHoJ