### PR TITLE
feat: add three difficulty levels to quiz game

### DIFF
--- a/src/components/CompletionScreen.jsx
+++ b/src/components/CompletionScreen.jsx
@@ -1,18 +1,26 @@
-import { Trophy, Target, CheckCircle } from 'lucide-react';
+import { Trophy, Target, CheckCircle, ArrowLeft, RotateCcw } from 'lucide-react';
 
-export const CompletionScreen = ({ score, correctAnswers, totalQuestions, onRestart }) => {
+export const CompletionScreen = ({ score, correctAnswers, totalQuestions, level, onRestart, onBackToLevels }) => {
   const accuracy = Math.round((correctAnswers / totalQuestions) * 100);
 
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 py-8 px-4">
       <div className="bg-white rounded-3xl shadow-2xl p-12 max-w-lg w-full text-center">
         <div className="mb-6">
           <Trophy className="w-24 h-24 text-yellow-500 mx-auto" />
         </div>
 
-        <h1 className="text-4xl font-bold text-gray-800 mb-6">
+        <h1 className="text-4xl font-bold text-gray-800 mb-2">
           Quiz Complete!
         </h1>
+
+        {level && (
+          <div className="mb-6">
+            <span className={`inline-block text-sm font-medium px-3 py-1 rounded-full bg-gradient-to-r ${level.color} text-white`}>
+              {level.name} - {level.subtitle}
+            </span>
+          </div>
+        )}
 
         <div className="bg-gradient-to-r from-indigo-500 to-purple-500 text-white rounded-2xl p-8 mb-8">
           <div className="text-5xl font-bold mb-2">{score}</div>
@@ -32,12 +40,23 @@ export const CompletionScreen = ({ score, correctAnswers, totalQuestions, onRest
           </div>
         </div>
 
-        <button
-          onClick={onRestart}
-          className="bg-gradient-to-r from-indigo-500 to-purple-500 text-white font-bold text-xl px-8 py-4 rounded-xl hover:scale-105 transition-transform duration-200 shadow-lg"
-        >
-          Practice Again
-        </button>
+        <div className="space-y-3">
+          <button
+            onClick={onRestart}
+            className="w-full bg-gradient-to-r from-indigo-500 to-purple-500 text-white font-bold text-xl px-8 py-4 rounded-xl hover:scale-105 transition-transform duration-200 shadow-lg flex items-center justify-center gap-2"
+          >
+            <RotateCcw className="w-5 h-5" />
+            Try Again
+          </button>
+
+          <button
+            onClick={onBackToLevels}
+            className="w-full bg-gray-100 text-gray-700 font-bold text-lg px-8 py-4 rounded-xl hover:bg-gray-200 transition-colors duration-200 flex items-center justify-center gap-2"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            Choose Another Level
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/LevelSelect.jsx
+++ b/src/components/LevelSelect.jsx
@@ -1,0 +1,61 @@
+import { Code2, ChevronRight } from 'lucide-react';
+import { levels } from '../data/questions';
+
+export const LevelSelect = ({ onSelectLevel }) => {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 py-8 px-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="text-center mb-12">
+          <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-2xl mb-6 shadow-lg">
+            <Code2 className="w-10 h-10 text-white" />
+          </div>
+          <h1 className="text-4xl font-bold text-gray-800 mb-3">
+            Syntax Quiz
+          </h1>
+          <p className="text-gray-600 text-lg">
+            Test your TypeScript & JavaScript knowledge
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {levels.map((level) => (
+            <button
+              key={level.id}
+              onClick={() => onSelectLevel(level)}
+              className="w-full bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-[1.02] p-6 text-left group"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className={`w-14 h-14 rounded-xl bg-gradient-to-r ${level.color} flex items-center justify-center shadow-md`}>
+                    <span className="text-2xl font-bold text-white">{level.id}</span>
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <h2 className="text-xl font-bold text-gray-800">
+                        {level.name}
+                      </h2>
+                      <span className={`text-sm font-medium px-2 py-0.5 rounded-full bg-gradient-to-r ${level.color} text-white`}>
+                        {level.subtitle}
+                      </span>
+                    </div>
+                    <p className="text-gray-600 mt-1">
+                      {level.description}
+                    </p>
+                    <p className="text-sm text-gray-400 mt-1">
+                      {level.questions.length} questions
+                    </p>
+                  </div>
+                </div>
+                <ChevronRight className="w-6 h-6 text-gray-400 group-hover:text-indigo-500 group-hover:translate-x-1 transition-all" />
+              </div>
+            </button>
+          ))}
+        </div>
+
+        <p className="text-center text-gray-500 mt-8 text-sm">
+          Choose a level to begin practicing
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/QuizHeader.jsx
+++ b/src/components/QuizHeader.jsx
@@ -1,12 +1,17 @@
 import { Flame, Star } from 'lucide-react';
 
-export const QuizHeader = ({ score, streak, currentQuestion, totalQuestions }) => {
+export const QuizHeader = ({ score, streak, currentQuestion, totalQuestions, level }) => {
   const progress = ((currentQuestion + 1) / totalQuestions) * 100;
 
   return (
     <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
       <div className="flex items-center justify-between mb-4">
-        <div className="flex gap-4">
+        <div className="flex items-center gap-4">
+          {level && (
+            <span className={`text-sm font-medium px-3 py-1.5 rounded-lg bg-gradient-to-r ${level.color} text-white`}>
+              {level.name}
+            </span>
+          )}
           <div className="flex items-center gap-2 bg-orange-500 text-white px-4 py-2 rounded-xl font-bold">
             <Flame size={20} />
             <span>{streak}</span>

--- a/src/data/questions.js
+++ b/src/data/questions.js
@@ -1,4 +1,5 @@
-export const questions = [
+// Level 1 - Easy: Basic syntax concepts that beginners should know
+export const level1Questions = [
   {
     code: `function greet(name: string) {
   return \`Hello, \${name}!\`;
@@ -51,20 +52,6 @@ greet('Alice');`,
     options: ["parentheses", "curly braces", "square brackets", "angle brackets"]
   },
   {
-    code: `const numbers: Array<number> = [1, 2, 3];`,
-    highlight: { start: 15, end: 28 },
-    question: "What is the highlighted part called?",
-    correct: "generic",
-    options: ["generic", "type parameter", "template", "type annotation"]
-  },
-  {
-    code: `type Status = 'active' | 'inactive' | 'pending';`,
-    highlight: { start: 14, end: 47 },
-    question: "What is the highlighted part called?",
-    correct: "union type",
-    options: ["union type", "intersection type", "literal type", "enum"]
-  },
-  {
     code: `interface User {
   name: string;
   age: number;
@@ -81,6 +68,55 @@ console.log(fruits[0]);`,
     question: "What is the highlighted part called?",
     correct: "index",
     options: ["index", "key", "position", "offset"]
+  },
+  {
+    code: `const add = (a, b) => a + b;`,
+    highlight: { start: 12, end: 27 },
+    question: "What is this syntax called?",
+    correct: "arrow function",
+    options: ["arrow function", "lambda", "anonymous function", "inline function"]
+  },
+  {
+    code: `async function fetchData() {
+  const data = await api.get('/users');
+  return data;
+}`,
+    highlight: { start: 44, end: 49 },
+    question: "What is this keyword called?",
+    correct: "await",
+    options: ["await", "async", "promise", "defer"]
+  },
+  {
+    code: `const point = { x: 10, y: 20 };`,
+    highlight: { start: 14, end: 30 },
+    question: "What is this syntax called?",
+    correct: "object literal",
+    options: ["object literal", "object notation", "hash", "dictionary"]
+  },
+  {
+    code: `const doubled = numbers.map(n => n * 2);`,
+    highlight: { start: 28, end: 38 },
+    question: "What is the function passed to map called?",
+    correct: "callback",
+    options: ["callback", "lambda", "handler", "delegate"]
+  }
+];
+
+// Level 2 - Medium: Intermediate TypeScript/JavaScript concepts
+export const level2Questions = [
+  {
+    code: `const numbers: Array<number> = [1, 2, 3];`,
+    highlight: { start: 15, end: 28 },
+    question: "What is the highlighted part called?",
+    correct: "generic",
+    options: ["generic", "type parameter", "template", "type annotation"]
+  },
+  {
+    code: `type Status = 'active' | 'inactive' | 'pending';`,
+    highlight: { start: 14, end: 47 },
+    question: "What is the highlighted part called?",
+    correct: "union type",
+    options: ["union type", "intersection type", "literal type", "enum"]
   },
   {
     code: `function getName(): string {
@@ -131,23 +167,6 @@ const name = user?.profile?.name;`,
     question: "What is this operator called?",
     correct: "nullish coalescing",
     options: ["nullish coalescing", "default operator", "fallback operator", "or operator"]
-  },
-  {
-    code: `const add = (a, b) => a + b;`,
-    highlight: { start: 12, end: 27 },
-    question: "What is this syntax called?",
-    correct: "arrow function",
-    options: ["arrow function", "lambda", "anonymous function", "inline function"]
-  },
-  {
-    code: `async function fetchData() {
-  const data = await api.get('/users');
-  return data;
-}`,
-    highlight: { start: 44, end: 49 },
-    question: "What is this keyword called?",
-    correct: "await",
-    options: ["await", "async", "promise", "defer"]
   },
   {
     code: `class Dog extends Animal {
@@ -203,7 +222,11 @@ const name = user?.profile?.name;`,
     question: "What is this declaration called?",
     correct: "enum",
     options: ["enum", "enumeration", "constant", "type"]
-  },
+  }
+];
+
+// Level 3 - Hard: Advanced TypeScript concepts
+export const level3Questions = [
   {
     code: `const value: unknown = getValue();
 const str = value as string;`,
@@ -227,20 +250,6 @@ const str = value as string;`,
     question: "What is this syntax called?",
     correct: "type guard",
     options: ["type guard", "type predicate", "type check", "type assertion"]
-  },
-  {
-    code: `const point = { x: 10, y: 20 };`,
-    highlight: { start: 14, end: 30 },
-    question: "What is this syntax called?",
-    correct: "object literal",
-    options: ["object literal", "object notation", "hash", "dictionary"]
-  },
-  {
-    code: `const doubled = numbers.map(n => n * 2);`,
-    highlight: { start: 28, end: 38 },
-    question: "What is the function passed to map called?",
-    correct: "callback",
-    options: ["callback", "lambda", "handler", "delegate"]
   },
   {
     code: `class User {
@@ -305,5 +314,36 @@ export function fetchData() { }`,
     question: "What is this type of export called?",
     correct: "named export",
     options: ["named export", "explicit export", "public export", "module export"]
+  }
+];
+
+// Combined questions for backwards compatibility
+export const questions = [...level1Questions, ...level2Questions, ...level3Questions];
+
+// Level metadata
+export const levels = [
+  {
+    id: 1,
+    name: "Level 1",
+    subtitle: "Easy",
+    description: "Basic syntax fundamentals",
+    questions: level1Questions,
+    color: "from-green-500 to-emerald-500"
+  },
+  {
+    id: 2,
+    name: "Level 2",
+    subtitle: "Medium",
+    description: "Intermediate concepts",
+    questions: level2Questions,
+    color: "from-yellow-500 to-orange-500"
+  },
+  {
+    id: 3,
+    name: "Level 3",
+    subtitle: "Hard",
+    description: "Advanced TypeScript",
+    questions: level3Questions,
+    color: "from-red-500 to-pink-500"
   }
 ];


### PR DESCRIPTION
- Reorganize questions into easy (12), medium (14), and hard (10) levels
- Add LevelSelect component for choosing difficulty
- Update QuizHeader to display current level
- Update CompletionScreen with "Try Again" and "Choose Another Level" options
- Level 1 (Easy): Basic syntax fundamentals like parameters, brackets, etc.
- Level 2 (Medium): Intermediate concepts like generics, destructuring, etc.
- Level 3 (Hard): Advanced TypeScript like type guards, conditional types, etc.

https://claude.ai/code/session_01C8d1tMgvKC8EdnooJAuhyd