### PR TITLE
fix: improve mobile header layout

### DIFF
--- a/src/components/QuizHeader.jsx
+++ b/src/components/QuizHeader.jsx
@@ -5,24 +5,24 @@ export const QuizHeader = ({ score, streak, currentQuestion, totalQuestions, lev
 
   return (
     <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-4">
+      <div className="flex items-center justify-between flex-wrap gap-2 mb-4">
+        <div className="flex items-center gap-2 sm:gap-4">
           {level && (
             <span className={`text-sm font-medium px-3 py-1.5 rounded-lg bg-gradient-to-r ${level.color} text-white`}>
               {level.name}
             </span>
           )}
-          <div className="flex items-center gap-2 bg-orange-500 text-white px-4 py-2 rounded-xl font-bold">
+          <div className="flex items-center gap-2 bg-orange-500 text-white px-3 sm:px-4 py-2 rounded-xl font-bold">
             <Flame size={20} />
             <span>{streak}</span>
           </div>
-          <div className="flex items-center gap-2 bg-yellow-500 text-white px-4 py-2 rounded-xl font-bold">
+          <div className="flex items-center gap-2 bg-yellow-500 text-white px-3 sm:px-4 py-2 rounded-xl font-bold">
             <Star size={20} />
             <span>{score}</span>
           </div>
         </div>
         <div className="text-gray-600 font-semibold">
-          Question {currentQuestion + 1} / {totalQuestions}
+          {currentQuestion + 1} / {totalQuestions}
         </div>
       </div>
       <div className="w-full bg-gray-200 rounded-full h-3 overflow-hidden">


### PR DESCRIPTION
- Remove "Question" prefix, now shows "1 / 14" format
- Add flex-wrap to allow header to wrap on mobile
- Reduce gaps and padding on mobile for better fit

https://claude.ai/code/session_01Knb8gMAr5bv4zUrz9NVzv3