### PR TITLE
Refactor QuizHeader styling for consistent height and spacing

### DIFF
--- a/src/components/QuizHeader.jsx
+++ b/src/components/QuizHeader.jsx
@@ -8,15 +8,15 @@ export const QuizHeader = ({ score, streak, currentQuestion, totalQuestions, lev
       <div className="flex items-center justify-between flex-wrap gap-2 mb-4">
         <div className="flex items-center gap-2 sm:gap-4">
           {level && (
-            <span className={`text-sm font-medium px-3 py-1.5 rounded-lg bg-gradient-to-r ${level.color} text-white`}>
+            <span className={`flex items-center h-9 text-sm font-medium px-3 sm:px-4 rounded-xl bg-gradient-to-r ${level.color} text-white font-bold`}>
               {level.name}
             </span>
           )}
-          <div className="flex items-center gap-2 bg-orange-500 text-white px-3 sm:px-4 py-2 rounded-xl font-bold">
+          <div className="flex items-center gap-2 h-9 bg-orange-500 text-white px-3 sm:px-4 rounded-xl font-bold">
             <Flame size={20} />
             <span>{streak}</span>
           </div>
-          <div className="flex items-center gap-2 bg-yellow-500 text-white px-3 sm:px-4 py-2 rounded-xl font-bold">
+          <div className="flex items-center gap-2 h-9 bg-yellow-500 text-white px-3 sm:px-4 rounded-xl font-bold">
             <Star size={20} />
             <span>{score}</span>
           </div>


### PR DESCRIPTION
## Summary
Updated the QuizHeader component's badge styling to use consistent fixed heights and improved responsive padding, resulting in a more polished and aligned appearance.

## Key Changes
- Standardized all badge elements (level, streak, score) to use `h-9` fixed height for vertical alignment
- Replaced `py-2` padding with height-based layout to eliminate inconsistent vertical spacing
- Enhanced level badge styling with `font-bold` for visual consistency with other badges
- Improved responsive padding on level badge (`px-3 sm:px-4`) to match streak and score badges
- Updated level badge border radius from `rounded-lg` to `rounded-xl` for design consistency

## Implementation Details
- All three badge components now share the same height (`h-9`) and border radius (`rounded-xl`), creating a unified visual appearance
- Removed vertical padding in favor of flexbox centering with fixed height, which is more reliable for consistent alignment
- Maintained responsive horizontal padding (`px-3 sm:px-4`) across all badges for proper spacing on mobile and desktop views

https://claude.ai/code/session_01CwxM9QhuJYRr3dkggdzkic