### PR TITLE
Fix feedback banner and expand MDN search documentation sources

### DIFF
--- a/src/components/FeedbackBanner.jsx
+++ b/src/components/FeedbackBanner.jsx
@@ -36,7 +36,7 @@ export const FeedbackBanner = ({ lastAnswer }) => {
           <XCircle size={24} />
           <span>
             Wrong! It was <MdnLink term={lastAnswer.term} className="text-red-800" />, not{' '}
-            <MdnLink term={lastAnswer.userAnswer} className="text-red-800" />
+            {lastAnswer.userAnswer}
           </span>
         </>
       )}

--- a/src/utils/mdnLinks.js
+++ b/src/utils/mdnLinks.js
@@ -47,6 +47,6 @@ export function getMdnUrl(term) {
   }
 
   // Fall back to Google search across multiple JS/TS documentation sites
-  const searchQuery = `${term} AND inurl:https://developer.mozilla.org OR inurl:https://javascript.info OR inurl:https://eloquentjavascript.net OR inurl:https://exploringjs.com OR inurl:https://www.typescriptlang.org/docs`;
+  const searchQuery = `${term} AND inurl:https://developer.mozilla.org OR inurl:https://javascript.info OR inurl:https://eloquentjavascript.net OR inurl:https://exploringjs.com OR inurl:https://www.typescriptlang.org/docs OR inurl:https://react.dev/docs`;
   return `https://www.google.com/search?q=${encodeURIComponent(searchQuery)}`;
 }


### PR DESCRIPTION
## Summary
This PR makes two improvements to the feedback system and documentation search functionality:

1. Fixes the feedback banner to display user answers as plain text instead of attempting to create MDN links for incorrect answers
2. Expands the fallback Google search to include React documentation

## Key Changes
- **FeedbackBanner.jsx**: Changed the user's incorrect answer from being wrapped in an `<MdnLink>` component to plain text. This prevents broken links when the user enters invalid or non-existent terms.
- **mdnLinks.js**: Added `https://react.dev/docs` to the fallback Google search query, expanding documentation coverage to include React alongside existing JavaScript/TypeScript resources.

## Implementation Details
The user answer in the feedback banner is now displayed as-is without attempting to generate an MDN link, which is more appropriate since incorrect user inputs may not correspond to valid documentation terms. The MDN search fallback now covers a broader range of modern web development documentation sources.

https://claude.ai/code/session_017A4mWNhDktRmMKDvMXpw1g