### PR TITLE
feat: bump mobile horizontal padding in PageLayout

### DIFF
--- a/src/components/PageLayout.jsx
+++ b/src/components/PageLayout.jsx
@@ -1,5 +1,5 @@
 export const PageLayout = ({ children, centered = false }) => (
-  <div className={`min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 py-8 px-4${centered ? ' flex items-center justify-center' : ''}`}>
+  <div className={`min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 py-8 px-6 sm:px-4${centered ? ' flex items-center justify-center' : ''}`}>
     {children}
   </div>
 );


### PR DESCRIPTION
px-4 → px-6 on mobile, back to px-4 at sm+. Gives the cards a bit
more breathing room from the viewport edges on small screens without
changing the desktop layout.

https://claude.ai/code/session_014ZLLatsTeR98eVXUXShcb6