### PR TITLE
Fix mobile scroll by restricting drag to grip handle

### DIFF
--- a/src/components/AnswerOptions.tsx
+++ b/src/components/AnswerOptions.tsx
@@ -29,22 +29,29 @@ const DraggableOption = ({
   return (
     <button
       ref={setNodeRef}
-      {...listeners}
       {...attributes}
       disabled={disabled}
       onClick={handleClick}
-      style={!disabled ? { touchAction: 'none' } : undefined}
       className={clsx(
         'flex items-center gap-3 p-4 rounded-xl border-2 border-gray-300',
         'bg-white text-gray-800 font-semibold text-lg',
         'transition-all duration-200',
         !disabled
-          ? 'hover:scale-105 hover:border-indigo-500 hover:shadow-lg cursor-move'
+          ? 'hover:scale-105 hover:border-indigo-500 hover:shadow-lg'
           : 'opacity-50 cursor-not-allowed',
         isDragging && 'opacity-40',
       )}
     >
-      <GripVertical className="text-gray-400 flex-shrink-0" size={20} />
+      <span
+        {...listeners}
+        className={clsx(
+          'relative flex-shrink-0 cursor-move',
+          "after:content-[''] after:absolute after:-inset-4",
+        )}
+        style={!disabled ? { touchAction: 'none' } : undefined}
+      >
+        <GripVertical className="text-gray-400" size={20} />
+      </span>
       <span className="flex-1 text-left">{option}</span>
     </button>
   );


### PR DESCRIPTION
Move dnd-kit drag listeners from the entire answer button to the
GripVertical icon handle. Uses a CSS pseudo-element (after:-inset-4) to
invisibly expand the handle's touch target while leaving the rest of
the button surface free for native scroll gestures and tap-to-answer.

https://claude.ai/code/session_01S7S4qvRThrRt7PoWZkXUDM