### PR TITLE
Fix level complete screen not centering on desktop

### DIFF
--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -17,7 +17,7 @@ export const PageLayout = ({ children, centered = false }: PageLayoutProps) => (
     >
       Skip to content
     </a>
-    <main id="main-content" className="w-full">
+    <main id="main-content" className={clsx('w-full', centered && 'flex flex-col items-center')}>
       {children}
     </main>
   </div>


### PR DESCRIPTION
When `centered` prop is true, the outer wrapper gets flex centering but
the inner <main> had `w-full` with no centering of its own children,
causing the completion card to be left-aligned. Adding `flex flex-col
items-center` to <main> when centered ensures the card is horizontally
centred within the full-width main element.

https://claude.ai/code/session_01CamNfJ75B9q3kXmPXFNWKB