### PR TITLE
Add global mute toggle with localStorage persistence

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,38 +1,53 @@
-import { Monitor, Sun, Moon } from 'lucide-react';
+import { Monitor, Sun, Moon, Volume2, VolumeX } from 'lucide-react';
 import { useTheme } from '../context/useTheme';
+import { useMute } from '../hooks/useMute';
 import type { ThemePreference } from '../context/themeContextValue';
 
-const options: { value: ThemePreference; icon: typeof Sun; label: string }[] = [
+const themeOptions: { value: ThemePreference; icon: typeof Sun; label: string }[] = [
   { value: 'system', icon: Monitor, label: 'System theme' },
   { value: 'light', icon: Sun, label: 'Light theme' },
   { value: 'dark', icon: Moon, label: 'Dark theme' },
 ];
 
+const btnBase =
+  'flex h-7 w-7 items-center justify-center rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]';
+const btnActive = `${btnBase} bg-neutral-100 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100`;
+const btnInactive = `${btnBase} text-neutral-400 hover:text-neutral-700 dark:text-neutral-500 dark:hover:text-neutral-300`;
+
 export const ThemeToggle = () => {
   const { theme, setTheme } = useTheme();
+  const { muted, toggleMute } = useMute();
 
   return (
     <div
       className="fixed bottom-3 right-3 z-50 flex items-center gap-0.5 rounded-lg border border-neutral-200 bg-white p-1 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 sm:bottom-auto sm:top-3"
       role="group"
-      aria-label="Theme preference"
+      aria-label="Display and sound controls"
     >
-      {options.map(({ value, icon: Icon, label }) => (
+      {themeOptions.map(({ value, icon: Icon, label }) => (
         <button
           key={value}
           type="button"
           onClick={() => setTheme(value)}
           aria-label={label}
           aria-pressed={theme === value}
-          className={
-            theme === value
-              ? 'flex h-7 w-7 items-center justify-center rounded-md bg-neutral-100 text-neutral-900 transition-colors dark:bg-neutral-800 dark:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]'
-              : 'flex h-7 w-7 items-center justify-center rounded-md text-neutral-400 transition-colors hover:text-neutral-700 dark:text-neutral-500 dark:hover:text-neutral-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]'
-          }
+          className={theme === value ? btnActive : btnInactive}
         >
           <Icon size={14} aria-hidden="true" />
         </button>
       ))}
+
+      <div className="mx-1 h-4 w-px bg-neutral-200 dark:bg-neutral-700" aria-hidden="true" />
+
+      <button
+        type="button"
+        onClick={toggleMute}
+        aria-label={muted ? 'Unmute sounds' : 'Mute sounds'}
+        aria-pressed={muted}
+        className={muted ? btnActive : btnInactive}
+      >
+        {muted ? <VolumeX size={14} aria-hidden="true" /> : <Volume2 size={14} aria-hidden="true" />}
+      </button>
     </div>
   );
 };

--- a/src/hooks/useMute.ts
+++ b/src/hooks/useMute.ts
@@ -1,0 +1,14 @@
+import { useState, useCallback } from 'react';
+import { isMuted, setMuted } from '../utils/sounds';
+
+export function useMute() {
+  const [muted, setMutedState] = useState(isMuted);
+
+  const toggleMute = useCallback(() => {
+    const next = !isMuted();
+    setMuted(next);
+    setMutedState(next);
+  }, []);
+
+  return { muted, toggleMute };
+}

--- a/src/utils/sounds.ts
+++ b/src/utils/sounds.ts
@@ -5,6 +5,15 @@ const SOUND_URLS = {
   keycap: 'https://cdn.freesound.org/previews/378/378085_6260145-lq.mp3',
 } as const;
 
+const MUTE_KEY = 'syntax-quiz-muted';
+let _muted = typeof localStorage !== 'undefined' && localStorage.getItem(MUTE_KEY) === 'true';
+
+export function isMuted(): boolean { return _muted; }
+export function setMuted(v: boolean): void {
+  _muted = v;
+  if (typeof localStorage !== 'undefined') localStorage.setItem(MUTE_KEY, String(v));
+}
+
 type SoundKey = keyof typeof SOUND_URLS;
 
 // Pre-fetch raw bytes immediately at module load — no AudioContext needed yet.
@@ -127,6 +136,7 @@ function warmupAll(): void {
 }
 
 function enqueue(key: SoundKey): void {
+  if (_muted) return;
   warmupAll();
   queue.push(key);
   drain().catch(() => {});


### PR DESCRIPTION
Adds a mute button to the controls bar alongside the theme switcher,
separated by a vertical divider. Mute state defaults to off, is stored
in localStorage, and is checked before any sound is enqueued.

https://claude.ai/code/session_01NaV2wgBqgJLq8adBbLFWBj