### PR TITLE
Add pop sound effect for hint and skip buttons

### DIFF
--- a/src/components/HintButton.tsx
+++ b/src/components/HintButton.tsx
@@ -38,6 +38,7 @@ export const HintButton = ({ hint, hintsUsed, onUseHint, disabled }: HintButtonP
         <SubtleButton
           onClick={onUseHint}
           disabled={disabled}
+          data-sound="pop"
         >
           <Lightbulb size={16} aria-hidden="true" />
           {showEliminate ? 'Eliminate 2 answers (−50% points)' : 'Show hint (−50% points)'}

--- a/src/pages/QuestionsPage.tsx
+++ b/src/pages/QuestionsPage.tsx
@@ -183,6 +183,7 @@ export const QuestionsPage = () => {
               <div className="mt-4 text-center">
                 <SubtleButton
                   data-testid="skip-question"
+                  data-sound="pop"
                   onClick={handleSkip}
                   disabled={isAnswering}
                 >

--- a/src/utils/sounds.ts
+++ b/src/utils/sounds.ts
@@ -20,6 +20,7 @@ export function setMuted(v: boolean): void {
 }
 
 export const playKeycapSound = (): void => { ensureInit(); tiks.click(); };
+export const playPopSound = (): void => { ensureInit(); tiks.pop(); };
 export const playCorrectSound = (): void => { ensureInit(); tiks.success(); };
 export const playIncorrectSound = (): void => { ensureInit(); tiks.error(); };
 
@@ -47,7 +48,11 @@ if (typeof document !== 'undefined') {
   document.addEventListener('pointerdown', (e: PointerEvent) => {
     let el = e.target as Element | null;
     while (el && el !== document.documentElement) {
-      if (isInteractive(el)) { playKeycapSound(); return; }
+      if (isInteractive(el)) {
+        const sound = (el as HTMLElement).dataset?.sound;
+        if (sound === 'pop') playPopSound(); else playKeycapSound();
+        return;
+      }
       el = el.parentElement;
     }
   }, { passive: true });
@@ -63,6 +68,9 @@ if (typeof document !== 'undefined') {
       const type = (focused as HTMLInputElement).type;
       if (!['button', 'submit', 'reset', 'checkbox', 'radio'].includes(type)) return;
     }
-    if (isInteractive(focused)) playKeycapSound();
+    if (isInteractive(focused)) {
+      const sound = (focused as HTMLElement).dataset?.sound;
+      if (sound === 'pop') playPopSound(); else playKeycapSound();
+    }
   });
 }


### PR DESCRIPTION
## Summary
This PR adds a new pop sound effect that plays when users interact with hint and skip buttons, providing distinct audio feedback for these secondary actions compared to the standard keycap click sound.

## Key Changes
- Added `playPopSound()` export function in `sounds.ts` that triggers the pop sound from the tiks library
- Updated pointer and keyboard event listeners to check for a `data-sound` attribute on interactive elements
  - Elements with `data-sound="pop"` trigger the pop sound
  - All other interactive elements continue to use the keycap click sound
- Added `data-sound="pop"` attribute to:
  - HintButton component (for showing hints/eliminating answers)
  - Skip question button on QuestionsPage

## Implementation Details
The sound selection is determined by checking the `dataset.sound` property of the focused/clicked element. This approach allows for flexible sound assignment without modifying the core sound system, making it easy to add different sound effects to other interactive elements in the future.

https://claude.ai/code/session_01C7F7bmUmvNKJaukEMjWxgU