### PR TITLE
Add pre-commit hooks for automatic formatting and linting

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,7 @@ A React-based quiz application for testing syntax knowledge. The project is buil
 ## Testing & Quality
 
 - Always run `npm run typecheck` before committing
-- Run `npm run lint` to catch code quality issues
+- Formatting (oxfmt) and linting (oxlint) run automatically on staged files via a `simple-git-hooks` pre-commit hook (powered by `nano-staged`) — you do not need to run them manually
 - Test responsive design across different screen sizes
 - Verify animations work smoothly
 - **Note**: Currently, there is no automated test infrastructure in this project. When adding features, consider adding tests if appropriate, but they are not required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,9 @@ JavaScript and TypeScript developers at all levels practicing syntax terminology
 
 ## Code Formatting
 
-This project uses **oxfmt** (OXC formatter) with Prettier-compatible defaults. After each set of changes, run:
+This project uses **oxfmt** (OXC formatter) with Prettier-compatible defaults, and **oxlint** for linting. Both run automatically on staged files via a `simple-git-hooks` pre-commit hook (powered by `nano-staged`), so you do not need to run the formatter or linter manually — committing will format and lint the relevant files for you.
 
-```
-npm run format
-```
-
-oxfmt formats JS, TS, JSX, TSX, JSON, and related files. Do not manually adjust whitespace, quotes, or indentation — let the formatter handle it.
+oxfmt formats JS, TS, JSX, TSX, JSON, Markdown, CSS, HTML, and YAML files. Do not manually adjust whitespace, quotes, or indentation — let the formatter handle it.
 
 ## API Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,10 +41,12 @@
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "knip": "^6.0.0",
+        "nano-staged": "^1.0.2",
         "oxfmt": "^0.54.0",
         "oxlint": "^1.69.0",
         "postcss": "^8.5.6",
         "shiki": "^4.0.0",
+        "simple-git-hooks": "^2.13.1",
         "tailwindcss": "^4.1.18",
         "typescript": "^6.0.0",
         "vite": "^8.0.0",
@@ -9063,6 +9065,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nano-staged": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nano-staged/-/nano-staged-1.0.2.tgz",
+      "integrity": "sha512-Fytar3zHLY99nlMfqPPbraxZodqQAHPpdPRyYaplL+lB9DCR6pUrafxbG+Btz4+7fO5Rm/+DO4ZeDO/nLSUMhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "nano-staged": "lib/bin.js"
+      },
+      "engines": {
+        "node": "^22 || >= 24"
+      }
+    },
     "node_modules/nanoclone": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
@@ -10324,6 +10339,17 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-git-hooks": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
+      "integrity": "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "simple-git-hooks": "cli.js"
+      }
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prepare": "simple-git-hooks",
     "dev": "vite",
     "build": "tsc && vite build",
     "typecheck": "tsc && tsc -p netlify/tsconfig.json",
@@ -54,13 +55,25 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "knip": "^6.0.0",
+    "nano-staged": "^1.0.2",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",
     "postcss": "^8.5.6",
     "shiki": "^4.0.0",
+    "simple-git-hooks": "^2.13.1",
     "tailwindcss": "^4.1.18",
     "typescript": "^6.0.0",
     "vite": "^8.0.0",
     "vitest": "^4.0.18"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx nano-staged"
+  },
+  "nano-staged": {
+    "*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}": [
+      "oxlint --fix",
+      "oxfmt --no-error-on-unmatched-pattern"
+    ],
+    "*.{json,jsonc,md,css,html,yaml,yml}": "oxfmt --no-error-on-unmatched-pattern"
   }
 }


### PR DESCRIPTION
## Summary

Introduces automated code quality checks via Git pre-commit hooks. Formatting (oxfmt) and linting (oxlint) now run automatically on staged files before each commit, eliminating the need for manual formatter/linter invocation.

## Changes

- **Dependencies**: Added `simple-git-hooks` and `nano-staged` to dev dependencies
- **Git hooks**: Configured `simple-git-hooks` with a pre-commit hook that runs `nano-staged`
- **Staged file patterns**: Set up `nano-staged` to:
  - Run `oxlint --fix` and `oxfmt --no-error-on-unmatched-pattern` on JS/TS/JSX/TSX files
  - Run `oxfmt --no-error-on-unmatched-pattern` on JSON, Markdown, CSS, HTML, and YAML files
- **npm script**: Added `prepare` script to initialize Git hooks on install
- **Documentation**: Updated CLAUDE.md and copilot-instructions.md to reflect that formatting and linting are now automatic and do not require manual execution

## Implementation Details

The setup uses `nano-staged` (a lightweight alternative to lint-staged) to selectively run formatters and linters only on staged files, keeping the pre-commit hook fast and focused. The `--no-error-on-unmatched-pattern` flag prevents oxfmt from failing when no matching files are found in a given pattern.

Developers no longer need to remember to run format/lint commands — committing will automatically format and lint the relevant files.

https://claude.ai/code/session_019Jt4w95kPYo9mqHpkUqAvW